### PR TITLE
Fix goreleaser args

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,6 +47,6 @@ jobs:
       uses: goreleaser/goreleaser-action@v6
       with:
         version: latest
-        args: release --rm-dist
+        args: release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
--rm-dist は古いオプションだったので、--clean に変更しておく。

https://github.com/yuta1402/switchbot-meter-exporter/actions/runs/12961420461/job/36156662576
>  ⨯ command failed                                   error=unknown flag: --rm-dist